### PR TITLE
ESM Build is not published to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
   "main": "./dist/index.js",
   "module": "./esm/index.js",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./esm/index.js"
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./esm/index.js",
+    }
   },
   "files": [
     "dist",
+    "esm",
     "yarn.lock"
   ],
   "scripts": {


### PR DESCRIPTION
The `files` array does not publish the ESM folder, causing errors when using v3 with `vite`. Also the `exports` config needs the `.` indentifier.