### PR TITLE
fix: typed Timezone.name

### DIFF
--- a/esm/types.d.ts
+++ b/esm/types.d.ts
@@ -11,7 +11,7 @@ interface Country {
 }
 
 interface Timezone {
-  name: string;
+  name: TimezoneName;
   countries: CountryCode[];
   utcOffset: number;
   utcOffsetStr: string;


### PR DESCRIPTION
`Timezone.name` should be of type `TypezoneName` instead of string, increases type safety.