### PR TITLE
ci: set up conventional commits PR check

### DIFF
--- a/.github/workflows/conventional-commits-pr.yml
+++ b/.github/workflows/conventional-commits-pr.yml
@@ -1,0 +1,21 @@
+name: "Conventional Commits PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Wires up https://github.com/marketplace/actions/semantic-pull-request to ensure PR titles follow [conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/).
